### PR TITLE
Deploy da API de consumo dos modelos com Render

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
 
-from schemas import LabFeatures, SequenceFeatures
-from model.lab_feature      import model_predict as lab_predict
-from model.sequence_feature import model_predict as sequence_predict
+from app.schemas import LabFeatures, SequenceFeatures
+from app.model.lab_feature      import model_predict as lab_predict
+from app.model.sequence_feature import model_predict as sequence_predict
 
 app = FastAPI()
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  # A Docker web service
+  - type: web
+    name: fastapi-protein
+    runtime: python
+    plan: free
+    autoDeploy: false
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn api:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
- Adiciona arquivos para deploy utilizando o plano free do Render
- Docs: https://github.com/render-examples/fastapi/tree/main